### PR TITLE
Fix typo and broken links

### DIFF
--- a/src/chapters/07-vim-goodies.md
+++ b/src/chapters/07-vim-goodies.md
@@ -147,7 +147,7 @@ I want to change all the fruits to `fruit`, but I realized it after I already ch
 
 After I change it I can just go to the next word (preferably with `w`) and press `.` to change the current word to `fruit`.
 
-You can do cool stuff with when combining `:help gn`
+You can do cool stuff when combining `.` with `:help gn`
 
 ## External Command
 You can run external terminal commands from vim, for example: `!ls`

--- a/src/chapters/08-advanced-config.md
+++ b/src/chapters/08-advanced-config.md
@@ -268,7 +268,7 @@ Make sure to execute `:PackerInstall` to install the added plugin.
 
 After you installed your first plugin successfully it's time to set it up.
 
-Create `plugins/init.lua` file and copy the code that requires all submodules from [here](https://github.com/ofirgall/dotfiles/blob/master/editors/nvim/lua/plugins/init.lua) and add `require('plugins')` in `init.lua`.
+Create `plugins/init.lua` file and copy the code that requires all submodules from [here](https://github.com/ofirgall/dotfiles/blob/662cabe7977b29fa0dbeb1be2028437790810b86/editors/nvim/lua/plugins/init.lua) and add `require('plugins')` in `init.lua`.
 
 Now you can add each plugin setup to its corresponding file and restart nvim.
 

--- a/src/chapters/11-complete-engine.md
+++ b/src/chapters/11-complete-engine.md
@@ -35,4 +35,4 @@ The snippet engine requires a snippets source too, I use a personal fork of [vim
 
 ---
 
-# [My Complete and Snippet Engines Configuration](https://github.com/ofirgall/dotfiles/blob/master/editors/nvim/lua/plugins/autocomplete.lua)
+# [My Complete and Snippet Engines Configuration](https://github.com/KoalaVim/KoalaVim/blob/master/lua/KoalaVim/plugins/autocomplete.lua)

--- a/src/chapters/15-misc-and-summary.md
+++ b/src/chapters/15-misc-and-summary.md
@@ -78,7 +78,7 @@ export MANWIDTH=999
 ```
 
 ### More
-There are many many more plugins for neovim, you can check out [awesome-neovim](https://github.com/rockerBOO/awesome-neovim), and you can also my list - [packer.lua](https://github.com/ofirgall/dotfiles/blob/master/editors/nvim/lua/plugins/packer.lua)
+There are many many more plugins for neovim, you can check out [awesome-neovim](https://github.com/rockerBOO/awesome-neovim), and you can also [my list](https://github.com/KoalaVim/KoalaVim/tree/master/lua/KoalaVim/plugins)
 
 ---
 


### PR DESCRIPTION
1. Fix typo

2. (links) As I noticed, you moved nvim config 
- For `autocomplete` and `plugins`, I put links to Koala
- For `init.lua`, I put the permalink when the file existed in the initial repo
